### PR TITLE
fix build dev to not watch causing github action workflow timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
-      - name: Build extension (development)
-        run: npm run build:dev
-      
       - name: Build extension (production)
         run: npm run build
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,10 @@ jobs:
         run: |
           echo "Checking build artifacts..."
           ls -la dist/
-          ls -la dist-dev/
           ls -la *.zip
           
           echo "Verifying manifest.json exists in both builds..."
           test -f dist/manifest.json
-          test -f dist-dev/manifest.json
           
           echo "Verifying main files exist..."
           test -f dist/background.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci
       
       - name: Build extension (development)
-        run: npm run dev
+        run: npm run build:dev
       
       - name: Build extension (production)
         run: npm run build

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "vite build --config vite.config.dev.js --watch",
     "build": "vite build",
-    "build:dev": "vite build --config vite.config.dev.js",
     "build:zip": "vite build && npm run zip",
     "zip": "node scripts/zip.js",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite build --config vite.config.dev.js --watch",
     "build": "vite build",
+    "build:dev": "vite build --config vite.config.dev.js",
     "build:zip": "vite build && npm run zip",
     "zip": "node scripts/zip.js",
     "preview": "vite preview",


### PR DESCRIPTION
The build action runs `npm run dev` which included the vite with `--watch` action which live rebuilds. This is an issue because effectively the job is stuck forever. There isn't a need to do this, so just use the "prod build"