### PR TITLE
[RFC] Spotlight-style URL bar 🔦

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ lerna-debug.log*
 *.sw?
 
 .config/
+
+# Vibe coding
+CLAUDE.md
+.claude/*

--- a/background.js
+++ b/background.js
@@ -1,5 +1,11 @@
 import { Utils } from './utils.js';
 
+// Enum for spotlight tab modes
+const SpotlightTabMode = {
+    CURRENT_TAB: 'current-tab',
+    NEW_TAB: 'new-tab'
+};
+
 const AUTO_ARCHIVE_ALARM_NAME = 'autoArchiveTabsAlarm';
 const TAB_ACTIVITY_STORAGE_KEY = 'tabLastActivity'; // Key to store timestamps
 
@@ -11,9 +17,9 @@ chrome.sidePanel.setPanelBehavior({
 
 // Listen for extension installation
 chrome.runtime.onInstalled.addListener((details) => {
-    if (details.reason === 'install' || details.reason === 'update') {
-        chrome.tabs.create({ url: 'onboarding.html', active: true });
-    }
+    // if (details.reason === 'install' || details.reason === 'update') {
+    //     chrome.tabs.create({ url: 'onboarding.html', active: true });
+    // }
     if (chrome.contextMenus) {
         chrome.contextMenus.create({
             id: "openArcify",
@@ -40,14 +46,62 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     }
 });
 
-chrome.commands.onCommand.addListener(function(command) {
+chrome.commands.onCommand.addListener(async function(command) {
     if (command === "quickPinToggle") {
         console.log("sending");
         // Send a message to the sidebar
         chrome.runtime.sendMessage({ command: "quickPinToggle" });
+    } else if (command === "toggleSpotlight") {
+        console.log("Spotlight (current tab) command received");
+        await injectSpotlightScript(SpotlightTabMode.CURRENT_TAB);
+    } else if (command === "toggleSpotlightNewTab") {
+        console.log("Spotlight (new tab) command received");
+        await injectSpotlightScript(SpotlightTabMode.NEW_TAB);
     }
 });
 
+// Helper function to inject spotlight script with spotlightTabMode
+async function injectSpotlightScript(spotlightTabMode) {
+    try {
+        // Get the active tab
+        const [tab] = await chrome.tabs.query({active: true, currentWindow: true});
+        if (tab) {
+            // First, set the spotlightTabMode and current URL in the content script context
+            await chrome.scripting.executeScript({
+                target: {tabId: tab.id},
+                func: (spotlightTabMode, currentUrl) => {
+                    window.arcifySpotlightTabMode = spotlightTabMode;
+                    window.arcifyCurrentTabUrl = currentUrl;
+                },
+                args: [spotlightTabMode, tab.url]
+            });
+            
+            // Then inject the spotlight overlay script
+            await chrome.scripting.executeScript({
+                target: {tabId: tab.id},
+                files: ['spotlight-overlay.js']
+            });
+            
+            // Notify sidebar about spotlight mode
+            // Needed to highlight the new tab button in the sidebar for new tab spotlight mode.
+            chrome.runtime.sendMessage({
+                action: 'spotlightOpened',
+                mode: spotlightTabMode
+            });
+        }
+    } catch (error) {
+        console.error("Error injecting spotlight script:", error);
+        // Fallback: open side panel if injection fails
+        try {
+            const [tab] = await chrome.tabs.query({active: true, currentWindow: true});
+            if (tab) {
+                chrome.sidePanel.open({windowId: tab.windowId});
+            }
+        } catch (fallbackError) {
+            console.error("Fallback to side panel also failed:", fallbackError);
+        }
+    }
+}
 
 // --- Helper: Update Last Activity Timestamp ---
 async function updateTabLastActivity(tabId) {
@@ -260,11 +314,124 @@ chrome.tabs.onRemoved.addListener(async (tabId, removeInfo) => {
 
 // Optional: Listen for messages from options page to immediately update alarm
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    console.log('[Background] Received message:', message.action);
+    
     if (message.action === 'updateAutoArchiveSettings') {
         console.log("Received message to update auto-archive settings.");
         setupAutoArchiveAlarm();
         sendResponse({ success: true });
+        return false; // Synchronous response
+    } else if (message.action === 'openNewTab') {
+        console.log("Opening new tab with URL:", message.url);
+        chrome.tabs.create({ url: message.url });
+        sendResponse({ success: true });
+        return false; // Synchronous response
+    } else if (message.action === 'switchToTab') {
+        // Handle tab switching for spotlight search results
+        (async () => {
+            try {
+                console.log('[Background] Switching to tab:', message.tabId, 'in window:', message.windowId);
+                await chrome.tabs.update(message.tabId, { active: true });
+                await chrome.windows.update(message.windowId, { focused: true });
+                console.log('[Background] Successfully switched to tab');
+                sendResponse({ success: true });
+            } catch (error) {
+                console.error('[Background] Error switching to tab:', error);
+                sendResponse({ success: false, error: error.message });
+            }
+        })();
+        return true; // Async response
+    } else if (message.action === 'searchTabs') {
+        // Handle async operation properly
+        (async () => {
+            try {
+                console.log('[Background] Searching tabs with query:', message.query);
+                const tabs = await chrome.tabs.query({});
+                const query = message.query?.toLowerCase() || '';
+                const filteredTabs = tabs.filter(tab => {
+                    if (!tab.title || !tab.url) return false;
+                    if (!query) return true;
+                    return tab.title.toLowerCase().includes(query) || 
+                           tab.url.toLowerCase().includes(query);
+                });
+                console.log('[Background] Found tabs:', filteredTabs.length);
+                sendResponse({ success: true, tabs: filteredTabs });
+            } catch (error) {
+                console.error('[Background] Error searching tabs:', error);
+                sendResponse({ success: false, error: error.message });
+            }
+        })();
+        return true; // Async response
+    } else if (message.action === 'getRecentTabs') {
+        (async () => {
+            try {
+                console.log('[Background] Getting recent tabs, limit:', message.limit);
+                const tabs = await chrome.tabs.query({});
+                const storage = await chrome.storage.local.get([TAB_ACTIVITY_STORAGE_KEY]);
+                const activityData = storage[TAB_ACTIVITY_STORAGE_KEY] || {};
+                
+                const tabsWithActivity = tabs
+                    .filter(tab => tab.url && tab.title)
+                    .map(tab => ({
+                        ...tab,
+                        lastActivity: activityData[tab.id] || 0
+                    }))
+                    .sort((a, b) => (b.lastActivity || 0) - (a.lastActivity || 0))
+                    .slice(0, message.limit || 5);
+                    
+                console.log('[Background] Found recent tabs:', tabsWithActivity.length);
+                sendResponse({ success: true, tabs: tabsWithActivity });
+            } catch (error) {
+                console.error('[Background] Error getting recent tabs:', error);
+                sendResponse({ success: false, error: error.message });
+            }
+        })();
+        return true; // Async response
+    } else if (message.action === 'searchBookmarks') {
+        (async () => {
+            try {
+                console.log('[Background] Searching bookmarks with query:', message.query);
+                const bookmarks = await chrome.bookmarks.search(message.query);
+                const filteredBookmarks = bookmarks.filter(bookmark => bookmark.url);
+                console.log('[Background] Found bookmarks:', filteredBookmarks.length);
+                sendResponse({ success: true, bookmarks: filteredBookmarks });
+            } catch (error) {
+                console.error('[Background] Error searching bookmarks:', error);
+                sendResponse({ success: false, error: error.message });
+            }
+        })();
+        return true; // Async response
+    } else if (message.action === 'searchHistory') {
+        (async () => {
+            try {
+                console.log('[Background] Searching history with query:', message.query);
+                const historyItems = await chrome.history.search({
+                    text: message.query,
+                    maxResults: 10,
+                    startTime: Date.now() - (7 * 24 * 60 * 60 * 1000) // Last 7 days
+                });
+                console.log('[Background] Found history items:', historyItems.length);
+                sendResponse({ success: true, history: historyItems });
+            } catch (error) {
+                console.error('[Background] Error searching history:', error);
+                sendResponse({ success: false, error: error.message });
+            }
+        })();
+        return true; // Async response
+    } else if (message.action === 'getTopSites') {
+        (async () => {
+            try {
+                console.log('[Background] Getting top sites');
+                const topSites = await chrome.topSites.get();
+                console.log('[Background] Found top sites:', topSites.length);
+                sendResponse({ success: true, topSites: topSites });
+            } catch (error) {
+                console.error('[Background] Error getting top sites:', error);
+                sendResponse({ success: false, error: error.message });
+            }
+        })();
+        return true; // Async response
     }
-    // Keep the message channel open for asynchronous response if needed
-    // return true;
+    
+    return false; // No async response needed
 });

--- a/domManager.js
+++ b/domManager.js
@@ -442,6 +442,20 @@ export function setupQuickPinListener(moveTabToSpace, moveTabToPinned, moveTabTo
                     });
                 }
             });
+        } else if (request.action === "spotlightOpened") {
+            console.log("[Spotlight] Spotlight opened with mode:", request.mode);
+            // Highlight new tab button if spotlight is in new-tab mode
+            const newTabBtn = document.getElementById('newTabBtn');
+            if (request.mode === 'new-tab' && newTabBtn) {
+                newTabBtn.classList.add('spotlight-active');
+            }
+        } else if (request.action === "spotlightClosed") {
+            console.log("[Spotlight] Spotlight closed");
+            // Remove highlighting from new tab button
+            const newTabBtn = document.getElementById('newTabBtn');
+            if (newTabBtn) {
+                newTabBtn.classList.remove('spotlight-active');
+            }
         }
     });
 } 

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,13 @@
     "bookmarks",
     "alarms",
     "commands",
-    "favicon"
+    "favicon",
+    "scripting",
+    "topSites",
+    "history"
+  ],
+  "host_permissions": [
+    "<all_urls>"
   ],
   "side_panel": {
     "default_path": "sidebar.html"
@@ -54,6 +60,20 @@
         "mac": "Command+D"
       },
       "description": "Quick Pin/Unpin Tab"
+    },
+    "toggleSpotlight": {
+      "suggested_key": {
+        "default": "Ctrl+K",
+        "mac": "Command+K"
+      },
+      "description": "Current Tab URL"
+    },
+    "toggleSpotlightNewTab": {
+      "suggested_key": {
+        "default": "Ctrl+H",
+        "mac": "Command+H"
+      },
+      "description": "New Tab"
     }
   },
   "options_page": "options.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "arcify",
-  "version": "2.2.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "arcify",
-      "version": "2.2.0",
+      "version": "3.1.0",
       "license": "GPL-3.0",
       "devDependencies": {
         "archiver": "^6.0.1",

--- a/search-data-provider.js
+++ b/search-data-provider.js
@@ -1,0 +1,310 @@
+// search-data-provider.js - Chrome API integration for search data
+
+import { SearchResult, ResultType } from './search-types.js';
+
+export class SearchDataProvider {
+    constructor() {
+        this.tabsCache = new Map();
+        this.bookmarksCache = new Map();
+        this.topSitesCache = null;
+        this.cacheTimeout = 5000; // 5 second cache
+    }
+
+    // Main search method that combines all data sources
+    async search(query, mode = 'current-tab') {
+        const results = [];
+        const trimmedQuery = query.trim().toLowerCase();
+
+        if (!trimmedQuery) {
+            return this.getDefaultResults(mode);
+        }
+
+        // Get results from different sources in parallel
+        const [
+            openTabs,
+            bookmarks,
+            history,
+            topSites
+        ] = await Promise.all([
+            mode === 'new-tab' ? this.getOpenTabs(trimmedQuery) : Promise.resolve([]),
+            this.searchBookmarks(trimmedQuery),
+            this.searchHistory(trimmedQuery),
+            this.getTopSites()
+        ]);
+
+        // Add URL/search suggestions
+        if (this.isURL(trimmedQuery)) {
+            results.push(this.generateURLSuggestion(trimmedQuery));
+        } else {
+            results.push(this.generateSearchSuggestion(trimmedQuery));
+        }
+
+        // Add other results
+        results.push(...openTabs, ...bookmarks, ...history);
+        
+        // Add top sites that match query
+        const matchingTopSites = topSites.filter(site => 
+            site.title.toLowerCase().includes(trimmedQuery) ||
+            site.url.toLowerCase().includes(trimmedQuery)
+        );
+        results.push(...matchingTopSites);
+
+        // Score and sort results
+        return this.scoreAndSortResults(results, trimmedQuery);
+    }
+
+    // Get default results when no query (recent tabs, top sites)
+    async getDefaultResults(mode) {
+        const results = [];
+
+        if (mode === 'new-tab') {
+            // Show recent tabs for new tab mode
+            const recentTabs = await this.getRecentTabs(5);
+            results.push(...recentTabs);
+        }
+
+        // Show top sites as suggestions
+        const topSites = await this.getTopSites();
+        results.push(...topSites.slice(0, 4));
+
+        return results;
+    }
+
+    // Chrome tabs API integration
+    async getOpenTabs(query = '') {
+        try {
+            const tabs = await chrome.tabs.query({});
+            const results = [];
+
+            for (const tab of tabs) {
+                if (!tab.title || !tab.url) continue;
+                
+                const titleMatch = tab.title.toLowerCase().includes(query);
+                const urlMatch = tab.url.toLowerCase().includes(query);
+                
+                if (query === '' || titleMatch || urlMatch) {
+                    results.push(new SearchResult({
+                        type: ResultType.OPEN_TAB,
+                        title: tab.title,
+                        url: tab.url,
+                        favicon: tab.favIconUrl,
+                        metadata: { tabId: tab.id, windowId: tab.windowId }
+                    }));
+                }
+            }
+
+            return results;
+        } catch (error) {
+            console.error('Error querying tabs:', error);
+            return [];
+        }
+    }
+
+    // Get recent tabs by activity (using existing background tracking)
+    async getRecentTabs(limit = 5) {
+        try {
+            const tabs = await chrome.tabs.query({});
+            const storage = await chrome.storage.local.get(['tabLastActivity']);
+            const activityData = storage.tabLastActivity || {};
+
+            // Sort tabs by last activity
+            const tabsWithActivity = tabs
+                .filter(tab => tab.url && tab.title)
+                .map(tab => ({
+                    ...tab,
+                    lastActivity: activityData[tab.id] || 0
+                }))
+                .sort((a, b) => (b.lastActivity || 0) - (a.lastActivity || 0))
+                .slice(0, limit);
+
+            return tabsWithActivity.map(tab => new SearchResult({
+                type: ResultType.OPEN_TAB,
+                title: tab.title,
+                url: tab.url,
+                favicon: tab.favIconUrl,
+                metadata: { tabId: tab.id, windowId: tab.windowId }
+            }));
+        } catch (error) {
+            console.error('Error getting recent tabs:', error);
+            return [];
+        }
+    }
+
+    // Chrome bookmarks API integration
+    async searchBookmarks(query) {
+        try {
+            const bookmarks = await chrome.bookmarks.search(query);
+            const results = [];
+
+            for (const bookmark of bookmarks) {
+                if (bookmark.url) { // Only actual bookmarks, not folders
+                    results.push(new SearchResult({
+                        type: ResultType.BOOKMARK,
+                        title: bookmark.title,
+                        url: bookmark.url,
+                        metadata: { bookmarkId: bookmark.id }
+                    }));
+                }
+            }
+
+            return results;
+        } catch (error) {
+            console.error('Error searching bookmarks:', error);
+            return [];
+        }
+    }
+
+    // Chrome history API integration
+    async searchHistory(query) {
+        try {
+            const historyItems = await chrome.history.search({
+                text: query,
+                maxResults: 10,
+                startTime: Date.now() - (7 * 24 * 60 * 60 * 1000) // Last 7 days
+            });
+
+            return historyItems.map(item => new SearchResult({
+                type: ResultType.HISTORY,
+                title: item.title || item.url,
+                url: item.url,
+                metadata: { visitCount: item.visitCount, lastVisitTime: item.lastVisitTime }
+            }));
+        } catch (error) {
+            console.error('Error searching history:', error);
+            return [];
+        }
+    }
+
+    // Chrome topSites API integration
+    async getTopSites() {
+        try {
+            if (this.topSitesCache) {
+                return this.topSitesCache;
+            }
+
+            const topSites = await chrome.topSites.get();
+            const results = topSites.map(site => new SearchResult({
+                type: ResultType.TOP_SITE,
+                title: site.title,
+                url: site.url
+            }));
+
+            this.topSitesCache = results;
+            // Cache for 5 minutes
+            setTimeout(() => {
+                this.topSitesCache = null;
+            }, 5 * 60 * 1000);
+
+            return results;
+        } catch (error) {
+            console.error('Error getting top sites:', error);
+            return [];
+        }
+    }
+
+    // URL detection utility
+    isURL(text) {
+        // Check if it's already a complete URL
+        try {
+            new URL(text);
+            return true;
+        } catch {}
+
+        // Check for domain-like patterns
+        const domainPattern = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.([a-zA-Z]{2,}|[a-zA-Z]{2,}\.[a-zA-Z]{2,})$/;
+        if (domainPattern.test(text)) {
+            return true;
+        }
+
+        // Check for localhost
+        if (text === 'localhost' || text.startsWith('localhost:')) {
+            return true;
+        }
+
+        // Check for IP addresses
+        if (/^(\d{1,3}\.){3}\d{1,3}(:\d+)?$/.test(text)) {
+            const parts = text.split(':')[0].split('.');
+            return parts.every(part => {
+                const num = parseInt(part, 10);
+                return num >= 0 && num <= 255;
+            });
+        }
+
+        // Common URL patterns without protocol
+        if (/^[a-zA-Z0-9-]+\.(com|org|net|edu|gov|mil|int|co|io|ly|me|tv|app|dev|ai)([\/\?\#].*)?$/.test(text)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    // Generate URL suggestion
+    generateURLSuggestion(input) {
+        const url = input.startsWith('http') ? input : `https://${input}`;
+        return new SearchResult({
+            type: ResultType.URL_SUGGESTION,
+            title: `Navigate to ${url}`,
+            url: url,
+            score: 95 // High priority for URLs
+        });
+    }
+
+    // Generate search suggestion
+    generateSearchSuggestion(input) {
+        return new SearchResult({
+            type: ResultType.SEARCH_QUERY,
+            title: `Search for "${input}"`,
+            url: `https://www.google.com/search?q=${encodeURIComponent(input)}`,
+            score: 80,
+            metadata: { query: input }
+        });
+    }
+
+    // Score and sort results based on relevance
+    scoreAndSortResults(results, query) {
+        // Calculate relevance scores
+        results.forEach(result => {
+            result.score = this.calculateRelevanceScore(result, query);
+        });
+
+        // Sort by score (highest first) and limit to 8 results
+        return results
+            .sort((a, b) => b.score - a.score)
+            .slice(0, 8);
+    }
+
+    // Relevance scoring algorithm
+    calculateRelevanceScore(result, query) {
+        let baseScore = 0;
+
+        // Base scores by type (matching plan priorities)
+        switch (result.type) {
+            case ResultType.OPEN_TAB: baseScore = 100; break;
+            case ResultType.URL_SUGGESTION: baseScore = 95; break;
+            case ResultType.BOOKMARK: baseScore = 85; break;
+            case ResultType.SEARCH_QUERY: baseScore = 80; break;
+            case ResultType.TOP_SITE: baseScore = 70; break;
+            case ResultType.HISTORY: baseScore = 60; break;
+        }
+
+        // Boost for exact matches
+        const queryLower = query.toLowerCase();
+        const titleLower = result.title.toLowerCase();
+        const urlLower = result.url.toLowerCase();
+
+        if (titleLower === queryLower) baseScore += 20;
+        else if (titleLower.startsWith(queryLower)) baseScore += 15;
+        else if (titleLower.includes(queryLower)) baseScore += 10;
+
+        if (urlLower.includes(queryLower)) baseScore += 5;
+
+        // Boost recent activity for tabs and history
+        if (result.type === ResultType.HISTORY && result.metadata.lastVisitTime) {
+            const daysSinceVisit = (Date.now() - result.metadata.lastVisitTime) / (1000 * 60 * 60 * 24);
+            if (daysSinceVisit < 1) baseScore += 10;
+            else if (daysSinceVisit < 7) baseScore += 5;
+        }
+
+        return Math.max(0, baseScore);
+    }
+}

--- a/search-engine.js
+++ b/search-engine.js
@@ -1,0 +1,181 @@
+// search-engine.js - Main search engine with caching and debouncing
+
+import { SearchDataProvider } from './search-data-provider.js';
+import { ResultType, SpotlightMode } from './search-types.js';
+
+export class SearchEngine {
+    constructor() {
+        this.dataProvider = new SearchDataProvider();
+        this.cache = new Map();
+        this.searchTimeout = null;
+        this.DEBOUNCE_DELAY = 150; // 150ms for responsiveness
+        this.CACHE_TTL = 30000; // 30 second cache TTL
+    }
+
+    // Main search method with debouncing
+    search(query, mode = SpotlightMode.CURRENT_TAB) {
+        return new Promise((resolve) => {
+            clearTimeout(this.searchTimeout);
+
+            // Check cache first
+            const cacheKey = `${query.trim()}:${mode}`;
+            const cached = this.cache.get(cacheKey);
+            if (cached && Date.now() - cached.timestamp < this.CACHE_TTL) {
+                resolve(cached.results);
+                return;
+            }
+
+            // Debounced search
+            this.searchTimeout = setTimeout(async () => {
+                try {
+                    const results = await this.performSearch(query, mode);
+                    
+                    // Cache the results
+                    this.cache.set(cacheKey, {
+                        results,
+                        timestamp: Date.now()
+                    });
+
+                    resolve(results);
+                } catch (error) {
+                    console.error('Search error:', error);
+                    resolve([]);
+                }
+            }, this.DEBOUNCE_DELAY);
+        });
+    }
+
+    // Immediate search without debouncing (for programmatic calls)
+    async searchImmediate(query, mode = SpotlightMode.CURRENT_TAB) {
+        try {
+            return await this.performSearch(query, mode);
+        } catch (error) {
+            console.error('Immediate search error:', error);
+            return [];
+        }
+    }
+
+    // Internal search implementation
+    async performSearch(query, mode) {
+        const trimmedQuery = query.trim();
+        
+        if (!trimmedQuery) {
+            return await this.dataProvider.getDefaultResults(mode);
+        }
+
+        return await this.dataProvider.search(trimmedQuery, mode);
+    }
+
+    // Format result for display (Arc-style formatting)
+    formatResult(result, mode) {
+        const formatters = {
+            [ResultType.URL_SUGGESTION]: {
+                title: result.title,
+                subtitle: result.url,
+                action: '↵',
+                icon: '🔗'
+            },
+            [ResultType.SEARCH_QUERY]: {
+                title: result.title,
+                subtitle: 'Google Search',
+                action: '↵',
+                icon: '🔍'
+            },
+            [ResultType.OPEN_TAB]: {
+                title: result.title,
+                subtitle: result.domain,
+                action: mode === SpotlightMode.NEW_TAB ? 'Switch to Tab' : '↵',
+                icon: result.favicon || '🌐'
+            },
+            [ResultType.BOOKMARK]: {
+                title: result.title,
+                subtitle: result.domain,
+                action: '↵',
+                icon: result.favicon || '📖'
+            },
+            [ResultType.HISTORY]: {
+                title: result.title,
+                subtitle: result.domain,
+                action: '↵',
+                icon: result.favicon || '🕒'
+            },
+            [ResultType.TOP_SITE]: {
+                title: result.title,
+                subtitle: result.domain,
+                action: '↵',
+                icon: result.favicon || '⭐'
+            }
+        };
+
+        return formatters[result.type] || {
+            title: result.title,
+            subtitle: result.url,
+            action: '↵',
+            icon: '🌐'
+        };
+    }
+
+    // Handle result action (navigation, tab switching, etc.)
+    async handleResultAction(result, mode) {
+        try {
+            switch (result.type) {
+                case ResultType.OPEN_TAB:
+                    if (mode === SpotlightMode.NEW_TAB) {
+                        // Switch to existing tab
+                        await chrome.tabs.update(result.metadata.tabId, { active: true });
+                        await chrome.windows.update(result.metadata.windowId, { focused: true });
+                    } else {
+                        // Navigate current tab to the tab's URL
+                        window.location.href = result.url;
+                    }
+                    break;
+
+                case ResultType.URL_SUGGESTION:
+                case ResultType.BOOKMARK:
+                case ResultType.HISTORY:
+                case ResultType.TOP_SITE:
+                    if (mode === SpotlightMode.NEW_TAB) {
+                        // Send message to background to open new tab
+                        chrome.runtime.sendMessage({
+                            action: 'openNewTab',
+                            url: result.url
+                        });
+                    } else {
+                        // Navigate current tab
+                        window.location.href = result.url;
+                    }
+                    break;
+
+                case ResultType.SEARCH_QUERY:
+                    const searchUrl = `https://www.google.com/search?q=${encodeURIComponent(result.metadata.query)}`;
+                    if (mode === SpotlightMode.NEW_TAB) {
+                        chrome.runtime.sendMessage({
+                            action: 'openNewTab',
+                            url: searchUrl
+                        });
+                    } else {
+                        window.location.href = searchUrl;
+                    }
+                    break;
+
+                default:
+                    console.warn('Unknown result type:', result.type);
+            }
+        } catch (error) {
+            console.error('Error handling result action:', error);
+        }
+    }
+
+    // Clear cache (useful for testing or manual refresh)
+    clearCache() {
+        this.cache.clear();
+    }
+
+    // Get cache statistics
+    getCacheStats() {
+        return {
+            size: this.cache.size,
+            keys: Array.from(this.cache.keys())
+        };
+    }
+}

--- a/search-types.js
+++ b/search-types.js
@@ -1,0 +1,47 @@
+// search-types.js - Search result interfaces and constants for spotlight
+
+// Result type constants matching the plan
+export const ResultType = {
+    URL_SUGGESTION: 'url-suggestion',    // Direct URL navigation
+    SEARCH_QUERY: 'search-query',        // Google/default search
+    OPEN_TAB: 'open-tab',               // Switch to existing tab  
+    BOOKMARK: 'bookmark',                // Saved bookmark
+    HISTORY: 'history',                  // Browser history
+    TOP_SITE: 'top-site'                // Most visited site
+};
+
+// Search result interface
+export class SearchResult {
+    constructor({
+        type,
+        title,
+        url,
+        favicon = null,
+        score = 0,
+        metadata = {}
+    }) {
+        this.type = type;
+        this.title = title;
+        this.url = url;
+        this.favicon = favicon;
+        this.score = score;
+        this.metadata = metadata; // Extra data like tab ID, bookmark ID, etc.
+        this.domain = this.extractDomain(url);
+    }
+
+    extractDomain(url) {
+        try {
+            if (!url) return '';
+            const urlObj = new URL(url.startsWith('http') ? url : `https://${url}`);
+            return urlObj.hostname;
+        } catch {
+            return url; // Fallback for invalid URLs
+        }
+    }
+}
+
+// Spotlight mode constants
+export const SpotlightMode = {
+    CURRENT_TAB: 'current-tab',
+    NEW_TAB: 'new-tab'
+};

--- a/sidebar.js
+++ b/sidebar.js
@@ -1524,7 +1524,8 @@ function createNewTab(callback = () => {}) {
             if (space) {
                 space.temporaryTabs.push(tab.id);
                 saveSpaces();
-                if(callback) {
+                // Callback call fails sometimes with "callback is not a function" error.
+                if(typeof callback === 'function') {
                     callback();
                 }
             }

--- a/spotlight-overlay.js
+++ b/spotlight-overlay.js
@@ -1,0 +1,1099 @@
+// spotlight-overlay-fixed.js - Self-contained spotlight with embedded search
+// Privacy-safe content script injected on-demand only
+
+(function(spotlightTabMode = 'current-tab') {
+    
+    // Result type constants
+    const ResultType = {
+        URL_SUGGESTION: 'url-suggestion',
+        SEARCH_QUERY: 'search-query',
+        OPEN_TAB: 'open-tab',
+        BOOKMARK: 'bookmark',
+        HISTORY: 'history',
+        TOP_SITE: 'top-site'
+    };
+
+    // Spotlight mode constants
+    const SpotlightMode = {
+        CURRENT_TAB: 'current-tab',
+        NEW_TAB: 'new-tab'
+    };
+
+    // Enum for spotlight tab modes (declared inside IIFE to avoid redeclaration)
+    const SpotlightTabMode = {
+        CURRENT_TAB: 'current-tab',
+        NEW_TAB: 'new-tab'
+    };
+
+    // Search Result class
+    class SearchResult {
+        constructor({
+            type,
+            title,
+            url,
+            favicon = null,
+            score = 0,
+            metadata = {}
+        }) {
+            this.type = type;
+            this.title = title;
+            this.url = url;
+            this.favicon = favicon;
+            this.score = score;
+            this.metadata = metadata;
+            this.domain = this.extractDomain(url);
+        }
+
+        extractDomain(url) {
+            try {
+                if (!url) return '';
+                const urlObj = new URL(url.startsWith('http') ? url : `https://${url}`);
+                return urlObj.hostname;
+            } catch {
+                return url;
+            }
+        }
+    }
+
+    // Search Data Provider
+    class SearchDataProvider {
+        constructor() {
+            this.cache = new Map();
+            this.cacheTimeout = 5000;
+        }
+
+        // Main search method
+        async search(query, mode = 'current-tab') {
+            const results = [];
+            const trimmedQuery = query.trim().toLowerCase();
+            
+            console.log('[Spotlight] Starting search with query:', trimmedQuery, 'mode:', mode);
+
+            if (!trimmedQuery) {
+                console.log('[Spotlight] Empty query, getting default results');
+                return this.getDefaultResults(mode);
+            }
+
+            try {
+                console.log('[Spotlight] Fetching results from all sources...');
+                
+                // Get results from different sources with individual error handling
+                let openTabs = [];
+                let bookmarks = [];
+                let history = [];
+                let topSites = [];
+
+                // Get tabs (only in new-tab mode)
+                if (mode === 'new-tab') {
+                    try {
+                        openTabs = await this.getOpenTabs(trimmedQuery);
+                    } catch (error) {
+                        console.error('[Spotlight] Failed to get open tabs:', error);
+                        openTabs = [];
+                    }
+                }
+
+                // Get bookmarks
+                try {
+                    bookmarks = await this.searchBookmarks(trimmedQuery);
+                } catch (error) {
+                    console.error('[Spotlight] Failed to get bookmarks:', error);
+                    bookmarks = [];
+                }
+
+                // Get history
+                try {
+                    history = await this.searchHistory(trimmedQuery);
+                } catch (error) {
+                    console.error('[Spotlight] Failed to get history:', error);
+                    history = [];
+                }
+
+                // Get top sites
+                try {
+                    topSites = await this.getTopSites();
+                } catch (error) {
+                    console.error('[Spotlight] Failed to get top sites:', error);
+                    topSites = [];
+                }
+
+                console.log('[Spotlight] Individual results:');
+                console.log('  - Open tabs:', openTabs.length);
+                console.log('  - Bookmarks:', bookmarks.length);
+                console.log('  - History:', history.length);
+                console.log('  - Top sites:', topSites.length);
+
+                // Add URL/search suggestions
+                if (this.isURL(trimmedQuery)) {
+                    console.log('[Spotlight] Adding URL suggestion for:', trimmedQuery);
+                    results.push(this.generateURLSuggestion(trimmedQuery));
+                } else {
+                    console.log('[Spotlight] Adding search suggestion for:', trimmedQuery);
+                    results.push(this.generateSearchSuggestion(trimmedQuery));
+                }
+
+                // Add other results
+                results.push(...openTabs, ...bookmarks, ...history);
+                
+                // Add top sites that match query
+                const matchingTopSites = topSites.filter(site => 
+                    site.title.toLowerCase().includes(trimmedQuery) ||
+                    site.url.toLowerCase().includes(trimmedQuery)
+                );
+                console.log('[Spotlight] Matching top sites:', matchingTopSites.length);
+                results.push(...matchingTopSites);
+
+                console.log('[Spotlight] Total results before scoring:', results.length);
+                // Score and sort results
+                const finalResults = this.scoreAndSortResults(results, trimmedQuery);
+                console.log('[Spotlight] Final results after scoring:', finalResults.length);
+                return finalResults;
+            } catch (error) {
+                console.error('[Spotlight] Search error:', error);
+                return [this.generateFallbackResult(trimmedQuery)];
+            }
+        }
+
+        // Get default results when no query
+        async getDefaultResults(mode) {
+            const results = [];
+
+            try {
+                if (mode === 'new-tab') {
+                    // Show recent tabs for new tab mode
+                    const recentTabs = await this.getRecentTabs(5);
+                    results.push(...recentTabs);
+                }
+
+                // Show top sites as suggestions
+                const topSites = await this.getTopSites();
+                results.push(...topSites.slice(0, 4));
+            } catch (error) {
+                console.error('Error getting default results:', error);
+            }
+
+            return results;
+        }
+
+        // Chrome tabs API integration via background script
+        async getOpenTabs(query = '') {
+            try {
+                console.log('[Spotlight] Requesting tabs with query:', query);
+                const response = await chrome.runtime.sendMessage({
+                    action: 'searchTabs',
+                    query: query
+                });
+                
+                console.log('[Spotlight] Tabs response:', response);
+                if (response && response.success) {
+                    const results = response.tabs.map(tab => new SearchResult({
+                        type: ResultType.OPEN_TAB,
+                        title: tab.title,
+                        url: tab.url,
+                        favicon: tab.favIconUrl,
+                        metadata: { tabId: tab.id, windowId: tab.windowId }
+                    }));
+                    console.log('[Spotlight] Created tab results:', results.length);
+                    return results;
+                }
+                console.log('[Spotlight] No valid tabs response');
+                return [];
+            } catch (error) {
+                console.error('[Spotlight] Error querying tabs:', error);
+                return [];
+            }
+        }
+
+        // Get recent tabs by activity via background script
+        async getRecentTabs(limit = 5) {
+            try {
+                console.log('[Spotlight] Requesting recent tabs, limit:', limit);
+                const response = await chrome.runtime.sendMessage({
+                    action: 'getRecentTabs',
+                    limit: limit
+                });
+                
+                console.log('[Spotlight] Recent tabs response:', response);
+                if (response && response.success) {
+                    const results = response.tabs.map(tab => new SearchResult({
+                        type: ResultType.OPEN_TAB,
+                        title: tab.title,
+                        url: tab.url,
+                        favicon: tab.favIconUrl,
+                        metadata: { tabId: tab.id, windowId: tab.windowId }
+                    }));
+                    console.log('[Spotlight] Created recent tab results:', results.length);
+                    return results;
+                }
+                console.log('[Spotlight] No valid recent tabs response');
+                return [];
+            } catch (error) {
+                console.error('[Spotlight] Error getting recent tabs:', error);
+                return [];
+            }
+        }
+
+        // Chrome bookmarks API integration via background script
+        async searchBookmarks(query) {
+            try {
+                console.log('[Spotlight] Requesting bookmarks with query:', query);
+                const response = await chrome.runtime.sendMessage({
+                    action: 'searchBookmarks',
+                    query: query
+                });
+                
+                console.log('[Spotlight] Bookmarks response:', response);
+                if (response && response.success) {
+                    const results = response.bookmarks.map(bookmark => new SearchResult({
+                        type: ResultType.BOOKMARK,
+                        title: bookmark.title,
+                        url: bookmark.url,
+                        metadata: { bookmarkId: bookmark.id }
+                    }));
+                    console.log('[Spotlight] Created bookmark results:', results.length);
+                    return results;
+                }
+                console.log('[Spotlight] No valid bookmarks response');
+                return [];
+            } catch (error) {
+                console.error('[Spotlight] Error searching bookmarks:', error);
+                return [];
+            }
+        }
+
+        // Chrome history API integration via background script
+        async searchHistory(query) {
+            try {
+                console.log('[Spotlight] Requesting history with query:', query);
+                const response = await chrome.runtime.sendMessage({
+                    action: 'searchHistory',
+                    query: query
+                });
+                
+                console.log('[Spotlight] History response:', response);
+                if (response && response.success) {
+                    const results = response.history.map(item => new SearchResult({
+                        type: ResultType.HISTORY,
+                        title: item.title || item.url,
+                        url: item.url,
+                        metadata: { visitCount: item.visitCount, lastVisitTime: item.lastVisitTime }
+                    }));
+                    console.log('[Spotlight] Created history results:', results.length);
+                    return results;
+                }
+                console.log('[Spotlight] No valid history response');
+                return [];
+            } catch (error) {
+                console.error('[Spotlight] Error searching history:', error);
+                return [];
+            }
+        }
+
+        // Chrome topSites API integration via background script
+        async getTopSites() {
+            try {
+                console.log('[Spotlight] Requesting top sites');
+                const response = await chrome.runtime.sendMessage({
+                    action: 'getTopSites'
+                });
+                
+                console.log('[Spotlight] Top sites response:', response);
+                if (response && response.success) {
+                    const results = response.topSites.map(site => new SearchResult({
+                        type: ResultType.TOP_SITE,
+                        title: site.title,
+                        url: site.url
+                    }));
+                    console.log('[Spotlight] Created top sites results:', results.length);
+                    return results;
+                }
+                console.log('[Spotlight] No valid top sites response');
+                return [];
+            } catch (error) {
+                console.error('[Spotlight] Error getting top sites:', error);
+                return [];
+            }
+        }
+
+        // URL detection utility
+        isURL(text) {
+            // Check if it's already a complete URL
+            try {
+                new URL(text);
+                return true;
+            } catch {}
+
+            // Check for domain-like patterns
+            const domainPattern = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.([a-zA-Z]{2,}|[a-zA-Z]{2,}\.[a-zA-Z]{2,})$/;
+            if (domainPattern.test(text)) {
+                return true;
+            }
+
+            // Check for localhost
+            if (text === 'localhost' || text.startsWith('localhost:')) {
+                return true;
+            }
+
+            // Check for IP addresses
+            if (/^(\d{1,3}\.){3}\d{1,3}(:\d+)?$/.test(text)) {
+                const parts = text.split(':')[0].split('.');
+                return parts.every(part => {
+                    const num = parseInt(part, 10);
+                    return num >= 0 && num <= 255;
+                });
+            }
+
+            // Common URL patterns without protocol
+            if (/^[a-zA-Z0-9-]+\.(com|org|net|edu|gov|mil|int|co|io|ly|me|tv|app|dev|ai)([\/\?\#].*)?$/.test(text)) {
+                return true;
+            }
+
+            return false;
+        }
+
+        // Generate URL suggestion
+        generateURLSuggestion(input) {
+            const url = input.startsWith('http') ? input : `https://${input}`;
+            return new SearchResult({
+                type: ResultType.URL_SUGGESTION,
+                title: `Navigate to ${url}`,
+                url: url,
+                score: 95
+            });
+        }
+
+        // Generate search suggestion
+        generateSearchSuggestion(input) {
+            return new SearchResult({
+                type: ResultType.SEARCH_QUERY,
+                title: `Search for "${input}"`,
+                url: `https://www.google.com/search?q=${encodeURIComponent(input)}`,
+                score: 80,
+                metadata: { query: input }
+            });
+        }
+
+        // Generate fallback result for errors
+        generateFallbackResult(input) {
+            if (this.isURL(input)) {
+                return this.generateURLSuggestion(input);
+            } else {
+                return this.generateSearchSuggestion(input);
+            }
+        }
+
+        // Score and sort results
+        scoreAndSortResults(results, query) {
+            results.forEach(result => {
+                result.score = this.calculateRelevanceScore(result, query);
+            });
+
+            return results
+                .sort((a, b) => b.score - a.score)
+                .slice(0, 8);
+        }
+
+        // Relevance scoring algorithm
+        calculateRelevanceScore(result, query) {
+            let baseScore = 0;
+
+            switch (result.type) {
+                case ResultType.OPEN_TAB: baseScore = 100; break;
+                case ResultType.URL_SUGGESTION: baseScore = 95; break;
+                case ResultType.BOOKMARK: baseScore = 85; break;
+                case ResultType.SEARCH_QUERY: baseScore = 80; break;
+                case ResultType.TOP_SITE: baseScore = 70; break;
+                case ResultType.HISTORY: baseScore = 60; break;
+            }
+
+            const queryLower = query.toLowerCase();
+            const titleLower = result.title.toLowerCase();
+            const urlLower = result.url.toLowerCase();
+
+            if (titleLower === queryLower) baseScore += 20;
+            else if (titleLower.startsWith(queryLower)) baseScore += 15;
+            else if (titleLower.includes(queryLower)) baseScore += 10;
+
+            if (urlLower.includes(queryLower)) baseScore += 5;
+
+            return Math.max(0, baseScore);
+        }
+    }
+
+    // Search Engine with caching
+    class SearchEngine {
+        constructor() {
+            this.dataProvider = new SearchDataProvider();
+            this.cache = new Map();
+            this.searchTimeout = null;
+            this.DEBOUNCE_DELAY = 150;
+            this.CACHE_TTL = 30000;
+        }
+
+        // Main search method with debouncing
+        search(query, mode = SpotlightMode.CURRENT_TAB) {
+            return new Promise((resolve) => {
+                clearTimeout(this.searchTimeout);
+
+                // Check cache first
+                const cacheKey = `${query.trim()}:${mode}`;
+                const cached = this.cache.get(cacheKey);
+                if (cached && Date.now() - cached.timestamp < this.CACHE_TTL) {
+                    resolve(cached.results);
+                    return;
+                }
+
+                // Debounced search
+                this.searchTimeout = setTimeout(async () => {
+                    try {
+                        const results = await this.performSearch(query, mode);
+                        
+                        this.cache.set(cacheKey, {
+                            results,
+                            timestamp: Date.now()
+                        });
+
+                        resolve(results);
+                    } catch (error) {
+                        console.error('Search error:', error);
+                        resolve([]);
+                    }
+                }, this.DEBOUNCE_DELAY);
+            });
+        }
+
+        // Immediate search without debouncing
+        async searchImmediate(query, mode = SpotlightMode.CURRENT_TAB) {
+            try {
+                return await this.performSearch(query, mode);
+            } catch (error) {
+                console.error('Immediate search error:', error);
+                return [];
+            }
+        }
+
+        // Internal search implementation
+        async performSearch(query, mode) {
+            const trimmedQuery = query.trim();
+            
+            if (!trimmedQuery) {
+                return await this.dataProvider.getDefaultResults(mode);
+            }
+
+            return await this.dataProvider.search(trimmedQuery, mode);
+        }
+
+        // Format result for display
+        formatResult(result, mode) {
+            const formatters = {
+                [ResultType.URL_SUGGESTION]: {
+                    title: result.title,
+                    subtitle: result.url,
+                    action: '↵'
+                },
+                [ResultType.SEARCH_QUERY]: {
+                    title: result.title,
+                    subtitle: 'Google Search',
+                    action: '↵'
+                },
+                [ResultType.OPEN_TAB]: {
+                    title: result.title,
+                    subtitle: result.domain,
+                    action: mode === SpotlightMode.NEW_TAB ? 'Switch to Tab' : '↵'
+                },
+                [ResultType.BOOKMARK]: {
+                    title: result.title,
+                    subtitle: result.domain,
+                    action: '↵'
+                },
+                [ResultType.HISTORY]: {
+                    title: result.title,
+                    subtitle: result.domain,
+                    action: '↵'
+                },
+                [ResultType.TOP_SITE]: {
+                    title: result.title,
+                    subtitle: result.domain,
+                    action: '↵'
+                }
+            };
+
+            return formatters[result.type] || {
+                title: result.title,
+                subtitle: result.url,
+                action: '↵'
+            };
+        }
+
+        // Handle result action
+        async handleResultAction(result, mode) {
+            try {
+                switch (result.type) {
+                    case ResultType.OPEN_TAB:
+                        if (mode === SpotlightMode.NEW_TAB) {
+                            // Send message to background script to switch tabs
+                            chrome.runtime.sendMessage({
+                                action: 'switchToTab',
+                                tabId: result.metadata.tabId,
+                                windowId: result.metadata.windowId
+                            });
+                        } else {
+                            window.location.href = result.url;
+                        }
+                        break;
+
+                    case ResultType.URL_SUGGESTION:
+                    case ResultType.BOOKMARK:
+                    case ResultType.HISTORY:
+                    case ResultType.TOP_SITE:
+                        if (mode === SpotlightMode.NEW_TAB) {
+                            chrome.runtime.sendMessage({
+                                action: 'openNewTab',
+                                url: result.url
+                            });
+                        } else {
+                            window.location.href = result.url;
+                        }
+                        break;
+
+                    case ResultType.SEARCH_QUERY:
+                        const searchUrl = `https://www.google.com/search?q=${encodeURIComponent(result.metadata.query)}`;
+                        if (mode === SpotlightMode.NEW_TAB) {
+                            chrome.runtime.sendMessage({
+                                action: 'openNewTab',
+                                url: searchUrl
+                            });
+                        } else {
+                            window.location.href = searchUrl;
+                        }
+                        break;
+
+                    default:
+                        console.warn('Unknown result type:', result.type);
+                }
+            } catch (error) {
+                console.error('Error handling result action:', error);
+            }
+        }
+    }
+    
+    // Handle toggle functionality for existing spotlight
+    const existingDialog = document.getElementById('arcify-spotlight-dialog');
+    if (existingDialog) {
+        if (existingDialog.open) {
+            existingDialog.close();
+        } else {
+            existingDialog.showModal();
+            const input = existingDialog.querySelector('.arcify-spotlight-input');
+            if (input) {
+                setTimeout(() => {
+                    input.focus();
+                    input.select();
+                    input.scrollLeft = 0;
+                }, 50);
+            }
+        }
+        return;
+    }
+    
+    // Mark as injected only when creating new dialog
+    window.arcifySpotlightInjected = true;
+
+    // CSS styles (same as before)
+    const spotlightCSS = `
+        #arcify-spotlight-dialog {
+            border: none;
+            padding: 0;
+            background: transparent;
+            border-radius: 12px;
+            width: 650px;
+            max-width: 90vw;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+        }
+
+        #arcify-spotlight-dialog::backdrop {
+            background: rgba(0, 0, 0, 0.4);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+        }
+
+        .arcify-spotlight-container {
+            background: #2D2D2D;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            padding: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            color: #ffffff;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .arcify-spotlight-input-wrapper {
+            display: flex;
+            align-items: center;
+            padding: 12px 24px 12px 20px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .arcify-spotlight-search-icon {
+            width: 20px;
+            height: 20px;
+            margin-right: 12px;
+            opacity: 0.6;
+            flex-shrink: 0;
+        }
+
+        .arcify-spotlight-input {
+            flex: 1;
+            background: transparent;
+            border: none;
+            color: #ffffff;
+            font-size: 18px;
+            line-height: 24px;
+            padding: 8px 0;
+            outline: none;
+            font-weight: 400;
+        }
+
+        .arcify-spotlight-input::placeholder {
+            color: rgba(255, 255, 255, 0.5);
+        }
+
+        .arcify-spotlight-input:focus {
+            outline: none;
+        }
+
+        .arcify-spotlight-results {
+            max-height: 400px;
+            overflow-y: auto;
+            padding: 8px 0;
+        }
+
+        .arcify-spotlight-result-item {
+            display: flex;
+            align-items: center;
+            padding: 12px 24px 12px 20px;
+            cursor: pointer;
+            transition: background-color 0.15s ease;
+            border: none;
+            background: none;
+            width: 100%;
+            text-align: left;
+            color: inherit;
+            font-family: inherit;
+        }
+
+        .arcify-spotlight-result-item:hover,
+        .arcify-spotlight-result-item:focus {
+            background: rgba(139, 92, 246, 0.15);
+            outline: none;
+        }
+
+        .arcify-spotlight-result-item.selected {
+            background: rgba(139, 92, 246, 0.2);
+        }
+
+        .arcify-spotlight-result-favicon {
+            width: 20px;
+            height: 20px;
+            margin-right: 12px;
+            border-radius: 4px;
+            flex-shrink: 0;
+        }
+
+        .arcify-spotlight-result-content {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .arcify-spotlight-result-title {
+            font-size: 14px;
+            font-weight: 500;
+            color: #ffffff;
+            margin: 0 0 2px 0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .arcify-spotlight-result-url {
+            font-size: 12px;
+            color: rgba(255, 255, 255, 0.6);
+            margin: 0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .arcify-spotlight-result-action {
+            font-size: 12px;
+            color: rgba(139, 92, 246, 0.8);
+            margin-left: 12px;
+            flex-shrink: 0;
+        }
+
+        .arcify-spotlight-loading {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            color: rgba(255, 255, 255, 0.6);
+        }
+
+        .arcify-spotlight-empty {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            color: rgba(255, 255, 255, 0.6);
+            font-size: 14px;
+        }
+
+        #arcify-spotlight-dialog {
+            animation: arcify-spotlight-show 0.2s ease-out;
+        }
+
+        @keyframes arcify-spotlight-show {
+            from {
+                opacity: 0;
+                transform: scale(0.95) translateY(-10px);
+            }
+            to {
+                opacity: 1;
+                transform: scale(1) translateY(0);
+            }
+        }
+
+        @media (max-width: 640px) {
+            #arcify-spotlight-dialog {
+                width: 95vw;
+                margin: 20px auto;
+            }
+            
+            .arcify-spotlight-input {
+                font-size: 16px;
+            }
+        }
+    `;
+
+    // Create and inject styles
+    const styleSheet = document.createElement('style');
+    styleSheet.textContent = spotlightCSS;
+    document.head.appendChild(styleSheet);
+
+    // Create spotlight dialog
+    const dialog = document.createElement('dialog');
+    dialog.id = 'arcify-spotlight-dialog';
+    
+    dialog.innerHTML = `
+        <div class="arcify-spotlight-container">
+            <div class="arcify-spotlight-input-wrapper">
+                <svg class="arcify-spotlight-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="11" cy="11" r="8"></circle>
+                    <path d="m21 21-4.35-4.35"></path>
+                </svg>
+                <input 
+                    type="text" 
+                    class="arcify-spotlight-input" 
+                    placeholder="${spotlightTabMode === SpotlightTabMode.NEW_TAB ? 'Search or enter URL (opens in new tab)...' : 'Search or enter URL...'}"
+                    spellcheck="false"
+                    autocomplete="off"
+                    autocorrect="off"
+                    autocapitalize="off"
+                >
+            </div>
+            <div class="arcify-spotlight-results">
+                <div class="arcify-spotlight-loading">Loading...</div>
+            </div>
+        </div>
+    `;
+
+    document.body.appendChild(dialog);
+
+    // Get references to key elements
+    const input = dialog.querySelector('.arcify-spotlight-input');
+    const resultsContainer = dialog.querySelector('.arcify-spotlight-results');
+    
+    // Initialize search engine
+    const searchEngine = new SearchEngine();
+    let currentResults = [];
+
+    // Selection Manager
+    class SelectionManager {
+        constructor(container) {
+            this.container = container;
+            this.selectedIndex = 0;
+            this.results = [];
+        }
+
+        updateResults(newResults) {
+            this.results = newResults;
+            this.selectedIndex = 0;
+            this.updateVisualSelection();
+        }
+
+        moveSelection(direction) {
+            const maxIndex = this.results.length - 1;
+            
+            if (direction === 'down') {
+                this.selectedIndex = Math.min(this.selectedIndex + 1, maxIndex);
+            } else if (direction === 'up') {
+                this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
+            }
+            
+            this.updateVisualSelection();
+        }
+
+        moveToFirst() {
+            this.selectedIndex = 0;
+            this.updateVisualSelection();
+        }
+
+        moveToLast() {
+            this.selectedIndex = Math.max(0, this.results.length - 1);
+            this.updateVisualSelection();
+        }
+
+        getSelectedResult() {
+            return this.results[this.selectedIndex] || null;
+        }
+
+        updateVisualSelection() {
+            const items = this.container.querySelectorAll('.arcify-spotlight-result-item');
+            items.forEach((item, index) => {
+                item.classList.toggle('selected', index === this.selectedIndex);
+            });
+        }
+    }
+
+    const selectionManager = new SelectionManager(resultsContainer);
+
+    // Load initial results
+    async function loadInitialResults() {
+        try {
+            const mode = spotlightTabMode === SpotlightTabMode.NEW_TAB ? 'new-tab' : 'current-tab';
+            const results = await searchEngine.searchImmediate('', mode);
+            displayResults(results);
+        } catch (error) {
+            console.error('Error loading initial results:', error);
+            displayEmptyState();
+        }
+    }
+
+    // Pre-fill URL in current-tab mode
+    if (spotlightTabMode === SpotlightTabMode.CURRENT_TAB && window.arcifyCurrentTabUrl) {
+        input.value = window.arcifyCurrentTabUrl;
+        setTimeout(() => {
+            handleInput();
+        }, 10);
+    } else {
+        // Load initial results
+        loadInitialResults();
+    }
+
+    // Handle input changes
+    async function handleInput() {
+        const query = input.value.trim();
+        
+        if (!query) {
+            loadInitialResults();
+            return;
+        }
+
+        // Show loading state
+        resultsContainer.innerHTML = '<div class="arcify-spotlight-loading">Searching...</div>';
+
+        try {
+            const mode = spotlightTabMode === SpotlightTabMode.NEW_TAB ? 'new-tab' : 'current-tab';
+            const results = await searchEngine.search(query, mode);
+            displayResults(results);
+        } catch (error) {
+            console.error('Search error:', error);
+            displayEmptyState();
+        }
+    }
+
+    // Display search results
+    function displayResults(results) {
+        currentResults = results;
+        selectionManager.updateResults(results);
+
+        if (!results || results.length === 0) {
+            displayEmptyState();
+            return;
+        }
+
+        const mode = spotlightTabMode === SpotlightTabMode.NEW_TAB ? 'new-tab' : 'current-tab';
+        const html = results.map((result, index) => {
+            const formatted = searchEngine.formatResult(result, mode);
+            const isSelected = index === 0;
+            
+            return `
+                <button class="arcify-spotlight-result-item ${isSelected ? 'selected' : ''}" 
+                        data-index="${index}">
+                    <img class="arcify-spotlight-result-favicon" 
+                         src="${getFaviconUrl(result)}" 
+                         alt="favicon"
+                         onerror="this.src='data:image/svg+xml,${encodeURIComponent('<svg xmlns=\\"http://www.w3.org/2000/svg\\" viewBox=\\"0 0 24 24\\" fill=\\"none\\" stroke=\\"currentColor\\" stroke-width=\\"2\\"><circle cx=\\"11\\" cy=\\"11\\" r=\\"8\\"></circle><path d=\\"m21 21-4.35-4.35\\"></path></svg>')}'">
+                    <div class="arcify-spotlight-result-content">
+                        <div class="arcify-spotlight-result-title">${escapeHtml(formatted.title)}</div>
+                        <div class="arcify-spotlight-result-url">${escapeHtml(formatted.subtitle)}</div>
+                    </div>
+                    <div class="arcify-spotlight-result-action">${escapeHtml(formatted.action)}</div>
+                </button>
+            `;
+        }).join('');
+
+        resultsContainer.innerHTML = html;
+    }
+
+    // Get favicon URL with fallback
+    function getFaviconUrl(result) {
+        if (result.favicon && result.favicon.startsWith('http')) {
+            return result.favicon;
+        }
+        
+        if (result.url) {
+            try {
+                const url = new URL(result.url.startsWith('http') ? result.url : `https://${result.url}`);
+                return `https://www.google.com/s2/favicons?domain=${url.hostname}&sz=64`;
+            } catch {
+                // Fallback for invalid URLs
+            }
+        }
+
+        return `data:image/svg+xml,${encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.35-4.35"></path></svg>')}`;
+    }
+
+    // Display empty state
+    function displayEmptyState() {
+        resultsContainer.innerHTML = '<div class="arcify-spotlight-empty">Start typing to search tabs, bookmarks, and history</div>';
+        currentResults = [];
+        selectionManager.updateResults([]);
+    }
+
+    // Escape HTML utility
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
+    // Debounced input handler
+    let inputTimeout;
+    input.addEventListener('input', () => {
+        clearTimeout(inputTimeout);
+        inputTimeout = setTimeout(handleInput, 150);
+    });
+
+    // Handle result selection
+    async function handleResultAction(result) {
+        if (!result) return;
+
+        try {
+            const mode = spotlightTabMode === SpotlightTabMode.NEW_TAB ? 'new-tab' : 'current-tab';
+            await searchEngine.handleResultAction(result, mode);
+            closeSpotlight();
+        } catch (error) {
+            console.error('Error handling result action:', error);
+        }
+    }
+
+    // Keyboard navigation
+    input.addEventListener('keydown', (e) => {
+        if (!dialog.contains(document.activeElement)) {
+            return;
+        }
+
+        switch (e.key) {
+            case 'ArrowDown':
+                e.preventDefault();
+                e.stopPropagation();
+                selectionManager.moveSelection('down');
+                break;
+
+            case 'ArrowUp':
+                e.preventDefault();
+                e.stopPropagation();
+                selectionManager.moveSelection('up');
+                break;
+
+            case 'Home':
+                e.preventDefault();
+                e.stopPropagation();
+                selectionManager.moveToFirst();
+                break;
+
+            case 'End':
+                e.preventDefault();
+                e.stopPropagation();
+                selectionManager.moveToLast();
+                break;
+
+            case 'Enter':
+                e.preventDefault();
+                e.stopPropagation();
+                const selected = selectionManager.getSelectedResult();
+                if (selected) {
+                    handleResultAction(selected);
+                }
+                break;
+
+            case 'Escape':
+                e.preventDefault();
+                e.stopPropagation();
+                closeSpotlight();
+                break;
+        }
+    });
+
+    // Handle clicks on results
+    resultsContainer.addEventListener('click', (e) => {
+        const item = e.target.closest('.arcify-spotlight-result-item');
+        if (item) {
+            const index = parseInt(item.dataset.index);
+            const result = currentResults[index];
+            if (result) {
+                handleResultAction(result);
+            }
+        }
+    });
+
+    // Close spotlight function
+    function closeSpotlight() {
+        dialog.close();
+        
+        chrome.runtime.sendMessage({
+            action: 'spotlightClosed'
+        });
+        
+        setTimeout(() => {
+            if (dialog.parentNode) {
+                dialog.parentNode.removeChild(dialog);
+                styleSheet.parentNode.removeChild(styleSheet);
+                window.arcifySpotlightInjected = false;
+            }
+        }, 200);
+    }
+
+    // Handle backdrop clicks
+    dialog.addEventListener('click', (e) => {
+        if (e.target === dialog) {
+            closeSpotlight();
+        }
+    });
+
+    dialog.addEventListener('close', closeSpotlight);
+
+    // Show dialog and focus input
+    dialog.showModal();
+    
+    setTimeout(() => {
+        input.focus();
+        input.select();
+        input.scrollLeft = 0;
+    }, 50);
+
+})(window.arcifySpotlightTabMode);

--- a/spotlight-overlay.js
+++ b/spotlight-overlay.js
@@ -949,9 +949,7 @@
             return;
         }
 
-        // Show loading state
-        resultsContainer.innerHTML = '<div class="arcify-spotlight-loading">Searching...</div>';
-
+        // Keep previous results while searching (no loading state to avoid jittery UI)
         try {
             const mode = spotlightTabMode === SpotlightTabMode.NEW_TAB ? 'new-tab' : 'current-tab';
             const results = await searchEngine.search(query, mode);

--- a/spotlight-overlay.js
+++ b/spotlight-overlay.js
@@ -422,26 +422,30 @@
 
     // Function to get accent color CSS based on active space color
     function getAccentColorCSS(spaceColor) {
-        // Chrome extension color values (matching the sidebar color system)
+        // RGB values for each color name (matching --chrome-*-color variables in styles.css)
+        // We need this mapping to create rgba() variants with different opacities
+        // Can't directly reuse the constants in styles.css due to two reasons:
+        //   1. Color constants are in hexcode, cannot use this value in rgba
+        //   2. CSS is not directly available in content scripts
         const colorMap = {
-            grey: { main: '#ccc', alpha15: 'rgba(204, 204, 204, 0.15)', alpha20: 'rgba(204, 204, 204, 0.2)', alpha80: 'rgba(204, 204, 204, 0.8)' },
-            blue: { main: '#8bb3f3', alpha15: 'rgba(139, 179, 243, 0.15)', alpha20: 'rgba(139, 179, 243, 0.2)', alpha80: 'rgba(139, 179, 243, 0.8)' },
-            red: { main: '#ff9e97', alpha15: 'rgba(255, 158, 151, 0.15)', alpha20: 'rgba(255, 158, 151, 0.2)', alpha80: 'rgba(255, 158, 151, 0.8)' },
-            yellow: { main: '#ffe29f', alpha15: 'rgba(255, 226, 159, 0.15)', alpha20: 'rgba(255, 226, 159, 0.2)', alpha80: 'rgba(255, 226, 159, 0.8)' },
-            green: { main: '#8bda99', alpha15: 'rgba(139, 218, 153, 0.15)', alpha20: 'rgba(139, 218, 153, 0.2)', alpha80: 'rgba(139, 218, 153, 0.8)' },
-            pink: { main: '#fbaad7', alpha15: 'rgba(251, 170, 215, 0.15)', alpha20: 'rgba(251, 170, 215, 0.2)', alpha80: 'rgba(251, 170, 215, 0.8)' },
-            purple: { main: '#d6a6ff', alpha15: 'rgba(214, 166, 255, 0.15)', alpha20: 'rgba(214, 166, 255, 0.2)', alpha80: 'rgba(214, 166, 255, 0.8)' },
-            cyan: { main: '#a5e2ea', alpha15: 'rgba(165, 226, 234, 0.15)', alpha20: 'rgba(165, 226, 234, 0.2)', alpha80: 'rgba(165, 226, 234, 0.8)' }
+            grey: '204, 204, 204',
+            blue: '139, 179, 243',
+            red: '255, 158, 151',
+            yellow: '255, 226, 159',
+            green: '139, 218, 153',
+            pink: '251, 170, 215',
+            purple: '214, 166, 255',
+            cyan: '165, 226, 234'
         };
 
-        const colors = colorMap[spaceColor] || colorMap.purple; // Fallback to purple
+        const rgb = colorMap[spaceColor] || colorMap.purple; // Fallback to purple
 
         return `
             :root {
-                --spotlight-accent-color: ${colors.main};
-                --spotlight-accent-color-15: ${colors.alpha15};
-                --spotlight-accent-color-20: ${colors.alpha20};
-                --spotlight-accent-color-80: ${colors.alpha80};
+                --spotlight-accent-color: rgb(${rgb});
+                --spotlight-accent-color-15: rgba(${rgb}, 0.15);
+                --spotlight-accent-color-20: rgba(${rgb}, 0.2);
+                --spotlight-accent-color-80: rgba(${rgb}, 0.8);
             }
         `;
     }

--- a/styles.css
+++ b/styles.css
@@ -545,9 +545,14 @@ h3 {
     background-color: rgba(255, 255, 255, 0.3);
 }
 
+.new-tab-btn.spotlight-active {
+    background-color: rgba(255, 255, 255, 0.4);
+}
+
 .new-tab-btn span {
     font-size: 20px;
 }
+
 
 .space-switcher {
     display: flex;

--- a/vite.config.dev.js
+++ b/vite.config.dev.js
@@ -25,11 +25,12 @@ export default defineConfig({
         utils: resolve(__dirname, 'utils.js'),
         localstorage: resolve(__dirname, 'localstorage.js'),
         chromeHelper: resolve(__dirname, 'chromeHelper.js'),
-        icons: resolve(__dirname, 'icons.js')
+        icons: resolve(__dirname, 'icons.js'),
+        'spotlight-overlay': resolve(__dirname, 'spotlight-overlay.js')
       },
       output: {
         entryFileNames: (chunkInfo) => {
-          const mainScripts = ['background', 'sidebar-script', 'options-script', 'onboarding-script', 'utils', 'localstorage', 'chromeHelper', 'icons'];
+          const mainScripts = ['background', 'sidebar-script', 'options-script', 'onboarding-script', 'utils', 'localstorage', 'chromeHelper', 'icons', 'spotlight-overlay'];
           if (mainScripts.includes(chunkInfo.name)) {
             return chunkInfo.name === 'sidebar-script' ? 'sidebar.js' : 
                    chunkInfo.name === 'options-script' ? 'options.js' : 

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,12 +22,13 @@ export default defineConfig({
         utils: resolve(__dirname, 'utils.js'),
         localstorage: resolve(__dirname, 'localstorage.js'),
         chromeHelper: resolve(__dirname, 'chromeHelper.js'),
-        icons: resolve(__dirname, 'icons.js')
+        icons: resolve(__dirname, 'icons.js'),
+        'spotlight-overlay': resolve(__dirname, 'spotlight-overlay.js'),
       },
       output: {
         entryFileNames: (chunkInfo) => {
           // Keep original names for main scripts
-          const mainScripts = ['background', 'sidebar-script', 'options-script', 'onboarding-script', 'utils', 'localstorage', 'chromeHelper', 'icons'];
+          const mainScripts = ['background', 'sidebar-script', 'options-script', 'onboarding-script', 'utils', 'localstorage', 'chromeHelper', 'icons', 'spotlight-overlay'];
           if (mainScripts.includes(chunkInfo.name)) {
             return chunkInfo.name === 'sidebar-script' ? 'sidebar.js' : 
                    chunkInfo.name === 'options-script' ? 'options.js' : 
@@ -66,6 +67,14 @@ export default defineConfig({
         // Copy styles.css
         if (await fs.pathExists('styles.css')) {
           await fs.copy('styles.css', 'dist/styles.css');
+        }
+        
+        // Copy search modules for dynamic import
+        const searchModules = ['search-types.js', 'search-data-provider.js', 'search-engine.js'];
+        for (const module of searchModules) {
+          if (await fs.pathExists(module)) {
+            await fs.copy(module, `dist/${module}`);
+          }
         }
         
         // Copy LICENSE and README if they exist


### PR DESCRIPTION
One of my favorite parts of Arc is the spotlight-esque bar for current / new tab. I find the Chrome tabbar & URL bar hideous, and this was my main reason to stop using Arcify a couple of months ago. 

I took a page out of Nisarg's book and vibe coded my problem away :)

<img width="1728" height="1117" alt="image" src="https://github.com/user-attachments/assets/13f15c11-74b2-4b1a-9e9e-0f03e8c6eeb3" />


**This is WIP, I'm putting up an RFC PR to get feedback on the following:**
1. New features to add for v0 spotlight bar
2. Workflows I should test to ensure no other major usecases are broken
3. Feedback from usage on any bugs / UX improvements

### 👾 Current features:
1. Spotlight bar shows up on hotkey presses (Command + H for new tab, Command + K for updating current URL). 
  1. Hotkeys are easily updatable in extension settings (Keyboard Shortcuts), I'm using Command + T & Command + L respectively (same as Arc / Chrome defaults)
2. Bar recommends relevant items from open tabs, bookmarks, and history. Autocomplete is WIP
3. New tab button on sidebar highlights when the user is using new-tab mode of spotlight (to differ from the current-tab mode)
4. Spotlight allows switching to currently open tabs (bookmarked, pinned, etc.) [Only works in new-tab mode for spotlight, not current-tab]
    1. [RFC] Should spotlight do cross-space searching for open tabs? It currently auto-switches spaces when the user selects an open tab from another space

https://github.com/user-attachments/assets/16bb4b3a-f4cb-4e73-b8cc-7644d2adeec2

**NOTE:** The tabbar popping in & out is because Chrome remove the `chrome://flags/#enable-immersive-fullscreen-toolbar` flag 2 months ago. Can't cut out the bar completely (i hate it)

### 🐛 Known bugs: (i'll squash before merge)
1. Spotlight bar does not show up on Chrome Settings / Extension / Extension Store pages. Scripting is not allowed for these pages, trying to find a workaround.
    - **[RFC]** If we can't show spotlight on these, what should we do? Show an error toast on Arc sidebar? 
2. Spotlight is tab-specific, so you can have multiple tabs with the spotlight bar open. Differs from Arc UX, I'd like to close spotlight bar when user switches tabs
3. It's a bit jittery when you're actively typing, going to make the UX better here
4. Spotlight can't keep up with you if you type too fast & press enter (if you type 'test' + enter very quick, it'll only get 'te')
6. Uses Google as the search engine, not the default engine shown in Chrome. Will update this (and the text shown)
7. Spotlight UI looks a bit weird on some websites (e.g. Bing, Chrome API documentation pages, etc.). Give me examples if you find more
8. If the user has clicked on the sidebar (e.g. clicked on a different tab) before opening spotlight, the bar does not auto-focus. User needs to click on spotlight before they can start typing

### [RFC] 📈Pending features:
1. Autocomplete for searching
2. Accent color of spotlight (currently purple-ish) should match the space color
3. Sidebar new tab button should open spotlight new tab mode instead of an empty chrome tab
4. [RFC] Comment with other feature ideas to add before merge

