### PR TITLE
Add drag-and-drop reordering for pinned folders

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -735,6 +735,36 @@ h3 {
     background-color: rgba(255, 255, 255, 0.2);
 }
 
+/* Folder drag and drop styles */
+.folder.dragging {
+    opacity: 0.5;
+    transform: scale(0.95);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.folder.drag-over {
+    border: 2px dashed rgba(0, 0, 0, 0.3);
+    background-color: rgba(255, 255, 255, 0.3);
+}
+
+.tabs-container.folder-drag-over {
+    position: relative;
+}
+
+.tabs-container.folder-drag-over::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 100, 255, 0.1);
+    border: 2px dashed rgba(0, 100, 255, 0.3);
+    border-radius: 8px;
+    pointer-events: none;
+    z-index: 10;
+}
+
 .new-tab-input {
     background-color: rgba(255, 255, 255, 0.3);
 }


### PR DESCRIPTION
- Implement folder drag-and-drop functionality within pinned sections
- Add visual feedback during dragging (opacity and scale changes)
- Persist folder order per space in local storage
- Scope dragging to pinned containers only (no cross-section dragging)
- Add helper functions: getDragAfterElementFolder, saveFolderOrder, loadAndApplyFolderOrder
- Integrate with existing folder creation and loading workflows
- Add CSS styling for drag feedback and drop zones
- Maintain compatibility with existing tab drag-and-drop functionality