### PR TITLE
Optimize content script URL permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,8 @@
   "content_scripts": [
     {
       "matches": [
-        "<all_urls>"
+        "http://*/*",
+        "https://*/*"
       ],
       "js": [
         "spotlight/overlay.js"


### PR DESCRIPTION
Update content script permissions to `http://*/*` and `https://*/*` to follow the principle of least privilege.

The spotlight content script only needs to run on regular web pages, as restricted URLs are already handled by a fallback mechanism in `background.js`. This change improves privacy and security without impacting functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bf00d71-0baf-4dc3-be11-63517f4d3911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6bf00d71-0baf-4dc3-be11-63517f4d3911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

